### PR TITLE
chore(deps): pin typescript to ^6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":automergeAll"],
   "prHourlyLimit": 1,
+  "packageRules": [
+    {
+      "description": "TS 7 (native compiler) is unsupported by Astro's language tooling; see withastro/astro#17268",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "^6"
+    }
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "extends": ["schedule:weekly"]


### PR DESCRIPTION
TypeScript 7 is the native (Go) compiler rewrite and is not yet supported by Astro's language tooling (`@astrojs/check` / `@astrojs/language-server`). `astro check` crashes with `Cannot read properties of undefined (reading 'fileExists')`, breaking the build.

Blocked upstream on TypeScript itself exposing the language-service API that non-JS languages need — tracked in withastro/astro#17268 (`triage: unable to fix`). Pin to `^6` so Renovate stops reopening the v7 bump until Astro supports it.

Closes #238.